### PR TITLE
Allow later versions of React as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "Andrew Wilson <andrew@lightsinthesky.io>",
   "license": "MIT",
   "peerDependencies": {
-    "react": "^0.12.1"
+    "react": "*"
   },
   "dependencies": {
     "enquire.js": "^2.1.1"


### PR DESCRIPTION
Allow installing react-skeleton alongside any version of React.
As long as none of the newer versions of React is incompatible this should not be such a strict requirement. Using `*` to include beta releases of 0.13.