### PR TITLE
Added browserify/babelify to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
   },
   "dependencies": {
     "enquire.js": "^2.1.1"
+  },
+  "browserify": {
+    "transform": ["babelify"]
   }
 }


### PR DESCRIPTION
The module uses jsx in its exports. When using browserify this would mean passing the {global:true} option to babel which significantly slows down builds. Instead add babelify to the package.json.
